### PR TITLE
Allow processing single file multiple times

### DIFF
--- a/src/helpers/defineMessagesAnalyzer.ts
+++ b/src/helpers/defineMessagesAnalyzer.ts
@@ -3,9 +3,9 @@ import * as ESTree from 'estree';
 import { Dictionary, CallExpressionNode } from "./types";
 
 type TrackedMessage = {
+  isReported: boolean;
   node: ESTree.Property;
   context: Rule.RuleContext;
-  isReported: boolean;
 }
 
 type MessageId = string | number;

--- a/src/helpers/defineMessagesAnalyzer.ts
+++ b/src/helpers/defineMessagesAnalyzer.ts
@@ -47,15 +47,24 @@ export default class DefineMessagesDuplicationAnalyzer {
   public clearFile = (filename: string): void => {
     const ids = this.messageIdsByFilename[filename];
 
-    ids?.forEach((id) => this.fileNamesById[id]?.delete(filename));
+    ids?.forEach((id) => {
+      this.fileNamesById[id]?.delete(filename);
+      if (this.fileNamesById[id]?.size === 0) {
+        delete this.fileNamesById[id];
+        delete this.messageById[id];
+      }
+    });
     delete this.messageIdsByFilename[filename];
   }
 
-  private addToFileTracker = (filename: string, messageId: MessageId): void => {
+  private trackMessageInFile = (filename: string, messageId: MessageId): void => {
     const ids = this.messageIdsByFilename[filename] ?? new Set();
     ids.add(messageId);
-
     this.messageIdsByFilename[filename] = ids;
+
+    const fileNames = this.fileNamesById[messageId] ?? new Set();
+    fileNames.add(filename);
+    this.fileNamesById[messageId] = fileNames;
   }
 
   private checkMessageDuplication = (messageNode: ESTree.Property, context: Rule.RuleContext): void => {
@@ -65,25 +74,21 @@ export default class DefineMessagesDuplicationAnalyzer {
     }
 
     const filename = context.getFilename();
-    const existingFilenames = this.fileNamesById[messageId] ?? new Set();
+    const firstTrackedMessage = this.messageById[messageId];
 
-    if (existingFilenames.size === 0) {
-      this.fileNamesById[messageId] = new Set([filename]);
-      this.addToFileTracker(filename, messageId);
+    if (firstTrackedMessage === undefined) {
+      this.trackMessageInFile(filename, messageId);
       this.messageById[messageId] = { node: messageNode, context, isReported: false };
       return;
     }
 
-    const firstOccurrence = this.messageById[messageId];
-    if (firstOccurrence !== undefined && !firstOccurrence.isReported) {
-      firstOccurrence.isReported = true;
-      this.reportDuplication(messageId, firstOccurrence.context, firstOccurrence.node);
+    if (!firstTrackedMessage.isReported) {
+      firstTrackedMessage.isReported = true;
+      this.reportDuplication(messageId, firstTrackedMessage.context, firstTrackedMessage.node);
     }
 
     this.reportDuplication(messageId, context, messageNode);
-
-    this.addToFileTracker(filename, messageId);
-    existingFilenames.add(filename);
+    this.trackMessageInFile(filename, messageId);
   }
 
   public proceedDefineMessagesFunctionCall = (node: CallExpressionNode, context: Rule.RuleContext): void => {

--- a/src/helpers/defineMessagesAnalyzer.ts
+++ b/src/helpers/defineMessagesAnalyzer.ts
@@ -3,21 +3,21 @@ import * as ESTree from 'estree';
 import { Dictionary, CallExpressionNode } from "./types";
 
 type TrackedMessage = {
-  isReported: boolean,
-  node: ESTree.Property,
-  context: Rule.RuleContext,
-  filename: string,
+  node: ESTree.Property;
+  context: Rule.RuleContext;
+  isReported: boolean;
 }
 
 type MessageId = string | number;
 
 export default class DefineMessagesDuplicationAnalyzer {
-  private idTracker: Dictionary<MessageId, TrackedMessage> = {};
-  private fileIdTracker: Dictionary<string, Set<MessageId>> = {};
+  private messageById: Dictionary<MessageId, TrackedMessage> = {};
+  private fileNamesById: Dictionary<MessageId, Set<string>> = {};
+  private messageIdsByFilename: Dictionary<string, Set<MessageId>> = {};
 
   private reportDuplication = (
     messageId: MessageId, context: Rule.RuleContext, messageNode: ESTree.Property
-  ): void  => {
+  ): void => {
     context.report({
       message: `message with id '${messageId}' is duplicated`,
       node: messageNode,
@@ -25,10 +25,12 @@ export default class DefineMessagesDuplicationAnalyzer {
   }
 
   private getMessageId = (messageNode: ESTree.Property): number | string | null => {
-    const messageNodeProperies: ESTree.Property[] = messageNode.value.type === 'ObjectExpression' ?
+    const messageNodeProperties: ESTree.Property[] = messageNode.value.type === 'ObjectExpression' ?
       this.removeSpreadElements(messageNode.value.properties) : [];
 
-    const messageIdNode = messageNodeProperies.find((messagesProperty: ESTree.Property) => messagesProperty.key.type === 'Identifier' && messagesProperty.key.name === 'id');
+    const messageIdNode = messageNodeProperties.find(
+      (property: ESTree.Property) => (property.key.type === 'Identifier') && (property.key.name === 'id')
+    );
 
     if ((messageIdNode == null) || messageIdNode.value.type !== 'Literal') {
       return null;
@@ -43,43 +45,45 @@ export default class DefineMessagesDuplicationAnalyzer {
   }
 
   public clearFile = (filename: string): void => {
-    const ids = this.fileIdTracker[filename];
-    if (ids == null) {
-      return;
-    }
-    ids.forEach((id) => { delete this.idTracker[id]; });
-    delete this.fileIdTracker[filename];
+    const ids = this.messageIdsByFilename[filename];
+
+    ids?.forEach((id) => this.fileNamesById[id]?.delete(filename));
+    delete this.messageIdsByFilename[filename];
+  }
+
+  private addToFileTracker = (filename: string, messageId: MessageId): void => {
+    const ids = this.messageIdsByFilename[filename] ?? new Set();
+    ids.add(messageId);
+
+    this.messageIdsByFilename[filename] = ids;
   }
 
   private checkMessageDuplication = (messageNode: ESTree.Property, context: Rule.RuleContext): void => {
-    const messageId: string | number | null = this.getMessageId(messageNode);
+    const messageId = this.getMessageId(messageNode);
     if (messageId == null) {
       return;
     }
 
     const filename = context.getFilename();
-    const firstTrackedMessage = this.idTracker[messageId];
-    if (firstTrackedMessage == null) {
-      this.idTracker[messageId] = {
-        node: messageNode,
-        context: context,
-        isReported: false,
-        filename,
-      };
-      if (this.fileIdTracker[filename] == null) {
-        this.fileIdTracker[filename] = new Set();
-      }
-      this.fileIdTracker[filename]?.add(messageId);
+    const existingFilenames = this.fileNamesById[messageId] ?? new Set();
 
+    if (existingFilenames.size === 0) {
+      this.fileNamesById[messageId] = new Set([filename]);
+      this.addToFileTracker(filename, messageId);
+      this.messageById[messageId] = { node: messageNode, context, isReported: false };
       return;
+    }
+
+    const firstOccurrence = this.messageById[messageId];
+    if (firstOccurrence !== undefined && !firstOccurrence.isReported) {
+      firstOccurrence.isReported = true;
+      this.reportDuplication(messageId, firstOccurrence.context, firstOccurrence.node);
     }
 
     this.reportDuplication(messageId, context, messageNode);
 
-    if (!firstTrackedMessage.isReported) {
-      firstTrackedMessage.isReported = true;
-      this.reportDuplication(messageId, firstTrackedMessage.context, firstTrackedMessage.node);
-    }
+    this.addToFileTracker(filename, messageId);
+    existingFilenames.add(filename);
   }
 
   public proceedDefineMessagesFunctionCall = (node: CallExpressionNode, context: Rule.RuleContext): void => {
@@ -93,8 +97,8 @@ export default class DefineMessagesDuplicationAnalyzer {
   }
 
   private removeSpreadElements = (
-    allProperies: Array<ESTree.Property | ESTree.SpreadElement>
-  ): ESTree.Property[] => allProperies.filter((messageNode): messageNode is ESTree.Property => messageNode.type === 'Property')
+    allProperties: Array<ESTree.Property | ESTree.SpreadElement>
+  ): ESTree.Property[] => allProperties.filter((messageNode): messageNode is ESTree.Property => messageNode.type === 'Property')
 
   private getMessageNodeList = (node: CallExpressionNode): ESTree.Property[] => {
     const firstArgument = node.arguments[0];

--- a/src/helpers/defineMessagesAnalyzer.ts
+++ b/src/helpers/defineMessagesAnalyzer.ts
@@ -6,12 +6,14 @@ type TrackedMessage = {
   isReported: boolean,
   node: ESTree.Property,
   context: Rule.RuleContext,
+  filename: string,
 }
 
 type MessageId = string | number;
 
 export default class DefineMessagesDuplicationAnalyzer {
   private idTracker: Dictionary<MessageId, TrackedMessage> = {};
+  private fileIdTracker: Dictionary<string, Set<MessageId>> = {};
 
   private reportDuplication = (
     messageId: MessageId, context: Rule.RuleContext, messageNode: ESTree.Property
@@ -40,28 +42,43 @@ export default class DefineMessagesDuplicationAnalyzer {
     return null;
   }
 
+  public clearFile = (filename: string): void => {
+    const ids = this.fileIdTracker[filename];
+    if (ids == null) {
+      return;
+    }
+    ids.forEach((id) => { delete this.idTracker[id]; });
+    delete this.fileIdTracker[filename];
+  }
+
   private checkMessageDuplication = (messageNode: ESTree.Property, context: Rule.RuleContext): void => {
     const messageId: string | number | null = this.getMessageId(messageNode);
     if (messageId == null) {
       return;
     }
 
-    const firstTrakedMessage = this.idTracker[messageId];
-    if (firstTrakedMessage == null) {
+    const filename = context.getFilename();
+    const firstTrackedMessage = this.idTracker[messageId];
+    if (firstTrackedMessage == null) {
       this.idTracker[messageId] = {
         node: messageNode,
         context: context,
         isReported: false,
+        filename,
       };
+      if (this.fileIdTracker[filename] == null) {
+        this.fileIdTracker[filename] = new Set();
+      }
+      this.fileIdTracker[filename]?.add(messageId);
 
       return;
     }
 
     this.reportDuplication(messageId, context, messageNode);
 
-    if (!firstTrakedMessage.isReported) {
-      firstTrakedMessage.isReported = true;
-      this.reportDuplication(messageId, firstTrakedMessage.context, firstTrakedMessage.node);
+    if (!firstTrackedMessage.isReported) {
+      firstTrackedMessage.isReported = true;
+      this.reportDuplication(messageId, firstTrackedMessage.context, firstTrackedMessage.node);
     }
   }
 

--- a/src/rules/defineMessages.ts
+++ b/src/rules/defineMessages.ts
@@ -6,6 +6,9 @@ const duplicationAnalyzer = new DuplicationAnalyzer();
 
 export default {
   create: (context: Rule.RuleContext): Rule.NodeListener => ({
+    Program: () => {
+      duplicationAnalyzer.clearFile(context.getFilename());
+    },
     CallExpression: (node: CallExpressionNode) => {
       duplicationAnalyzer.proceedDefineMessagesFunctionCall(node, context);
     },

--- a/tests/defineMessages.test.ts
+++ b/tests/defineMessages.test.ts
@@ -173,3 +173,105 @@ ruleTester.run(
     invalid: [],
   }
 );
+
+ruleTester.run(
+  'defineMessages duplicate multiple times and partially fix scenario. Step 1: initial state with duplications',
+  defineMessagesRule,
+  {
+    valid: [
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileA.ts',
+      },
+    ],
+    invalid: [
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileB.ts',
+        errors: [{ message: `message with id 'duplicateAndFixPartiallyScenario_id' is duplicated` }],
+      },
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileC.ts',
+        errors: [{ message: `message with id 'duplicateAndFixPartiallyScenario_id' is duplicated` }],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  'defineMessages duplicate multiple times and partially fix scenario. Step 2: Some duplication are fixed',
+  defineMessagesRule,
+  {
+    valid: [
+      {
+        code: `defineMessages({})`,
+        filename: 'duplicateAndFixPartiallyFileB.ts',
+      },
+    ],
+    invalid: [
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileA.ts',
+        errors: [{ message: `message with id 'duplicateAndFixPartiallyScenario_id' is duplicated` }],
+      },
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileC.ts',
+        errors: [{ message: `message with id 'duplicateAndFixPartiallyScenario_id' is duplicated` }],
+      },
+    ],
+  }
+);
+
+ruleTester.run(
+  'defineMessages duplicate multiple times and partially fix scenario. Step 3: valid after duplicates are removed',
+  defineMessagesRule,
+  {
+    valid: [
+      {
+        code: `defineMessages({})`,
+        filename: 'duplicateAndFixPartiallyFileB.ts',
+      },
+      {
+        code: `defineMessages({})`,
+        filename: 'duplicateAndFixPartiallyFileC.ts',
+      },
+      {
+        code: `defineMessages({
+          message: {
+            id: 'duplicateAndFixPartiallyScenario_id',
+            defaultMessage: 'message',
+          },
+        })`,
+        filename: 'duplicateAndFixPartiallyFileA.ts',
+      },
+    ],
+    invalid: [],
+  }
+);

--- a/tests/defineMessages.test.ts
+++ b/tests/defineMessages.test.ts
@@ -3,7 +3,7 @@ import defineMessagesRule from '../src/rules/defineMessages';
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('defineMessages rule single file usage', defineMessagesRule, {
+ruleTester.run('defineMessages rule. Single file usage', defineMessagesRule, {
   valid: [
     {
       code: `defineMessages({
@@ -42,7 +42,7 @@ ruleTester.run('defineMessages rule single file usage', defineMessagesRule, {
   ],
 });
 
-ruleTester.run('defineMessages rule multiple files usage', defineMessagesRule, {
+ruleTester.run('defineMessages rule. Multiple files usage', defineMessagesRule, {
   valid: [
     {
       code: `defineMessages({
@@ -71,26 +71,8 @@ ruleTester.run('defineMessages rule multiple files usage', defineMessagesRule, {
           defaultMessage: 'first default Message',
         },
       })`,
-      filename: 'messagesOne.ts',
-      errors: [
-        {
-          message: `message with id 'm_firstId' is duplicated`,
-        },
-      ],
-    },
-    {
-      code: `defineMessages({
-        firstMessage: {
-            id: 'm_firstId',
-            defaultMessage: 'first default Message',
-          },
-      })`,
-      filename: 'messagesTwo.ts',
-      errors: [
-        {
-          message: `message with id 'm_firstId' is duplicated`,
-        },
-      ],
+      filename: 'messagesThree.ts',
+      errors: [{ message: `message with id 'm_firstId' is duplicated` }],
     },
   ],
 });
@@ -123,4 +105,28 @@ ruleTester.run('defineMessages creates errors count equal to the same id usage a
       ],
     },
   ],
+});
+
+ruleTester.run('defineMessages processes same file multiple times do not give error', defineMessagesRule, {
+  valid: [
+    {
+      code: `defineMessages({
+        firstMessage: {
+          id: 'm_reusedId',
+          defaultMessage: 'first default Message',
+        },
+      })`,
+      filename: 'sameFile.ts',
+    },
+    {
+      code: `defineMessages({
+        secondMessage: {
+          id: 'm_reusedId',
+          defaultMessage: 'second default message',
+        },
+      })`,
+      filename: 'sameFile.ts',
+    },
+  ],
+  invalid: [],
 });

--- a/tests/defineMessages.test.ts
+++ b/tests/defineMessages.test.ts
@@ -139,7 +139,7 @@ ruleTester.run('defineMessages duplicate then fix scenario. Step 1: initial vali
   invalid: [],
 });
 
-ruleTester.run('defineMessages duplicate then fix scenario. Step 2: duplicate introduced', defineMessagesRule, {
+ruleTester.run('defineMessages duplicate then fix scenario. Step 2: duplicate is introduced', defineMessagesRule, {
   valid: [],
   invalid: [
     {
@@ -156,7 +156,7 @@ ruleTester.run('defineMessages duplicate then fix scenario. Step 2: duplicate in
 });
 
 ruleTester.run(
-  'defineMessages duplicate then fix scenario. Step 3: duplicate removed, valid again',
+  'defineMessages duplicate then fix scenario. Step 3: duplicate is removed, valid again',
   defineMessagesRule,
   {
     valid: [
@@ -250,7 +250,7 @@ ruleTester.run(
 );
 
 ruleTester.run(
-  'defineMessages duplicate multiple times and partially fix scenario. Step 3: valid after duplicates are removed',
+  'defineMessages duplicate multiple times and partially fix scenario. Step 3: valid after all duplicates are removed',
   defineMessagesRule,
   {
     valid: [

--- a/tests/defineMessages.test.ts
+++ b/tests/defineMessages.test.ts
@@ -8,36 +8,34 @@ ruleTester.run('defineMessages rule. Single file usage', defineMessagesRule, {
     {
       code: `defineMessages({
         firstMessage: {
-          id: 's_firstId',
+          id: 'single_firstId',
           defaultMessage: 'first default Message',
         },
         secondMessage: {
-          id: 's_secondId',
+          id: 'single_secondId',
           defaultMessage: 'second default message',
         },
       })`,
+      filename: 'singleValidMessage.ts',
     },
   ],
   invalid: [
     {
       code: `defineMessages({
         firstMessage: {
-          id: 's_thirdId',
+          id: 'single_thirdId',
           defaultMessage: 'first default Message',
         },
         secondMessage: {
-          id: 's_thirdId',
+          id: 'single_thirdId',
           defaultMessage: 'second default message',
         },
       })`,
       errors: [
-        {
-          message: `message with id 's_thirdId' is duplicated`,
-        },
-        {
-          message: `message with id 's_thirdId' is duplicated`,
-        },
+        { message: `message with id 'single_thirdId' is duplicated` },
+        { message: `message with id 'single_thirdId' is duplicated` },
       ],
+      filename: 'singleInvalidMessage.ts',
     },
   ],
 });
@@ -47,7 +45,7 @@ ruleTester.run('defineMessages rule. Multiple files usage', defineMessagesRule, 
     {
       code: `defineMessages({
         firstMessage: {
-          id: 'm_firstId',
+          id: 'multiple_firstId',
           defaultMessage: 'first default Message',
         },
       })`,
@@ -56,7 +54,7 @@ ruleTester.run('defineMessages rule. Multiple files usage', defineMessagesRule, 
     {
       code: `defineMessages({
         secondMessage: {
-          id: 'm_secondId',
+          id: 'multiple_secondId',
           defaultMessage: 'second default message',
         },
       })`,
@@ -67,12 +65,12 @@ ruleTester.run('defineMessages rule. Multiple files usage', defineMessagesRule, 
     {
       code: `defineMessages({
         firstMessage: {
-          id: 'm_firstId',
+          id: 'multiple_firstId',
           defaultMessage: 'first default Message',
         },
       })`,
       filename: 'messagesThree.ts',
-      errors: [{ message: `message with id 'm_firstId' is duplicated` }],
+      errors: [{ message: `message with id 'multiple_firstId' is duplicated` }],
     },
   ],
 });
@@ -83,25 +81,19 @@ ruleTester.run('defineMessages creates errors count equal to the same id usage a
     {
       code: `defineMessages({
         firstMessage: {
-          id: 'errorsAmoutCheck',
+          id: 'errorsAmountCheck',
         },
         firstMessage: {
-          id: 'errorsAmoutCheck',
+          id: 'errorsAmountCheck',
         },
         firstMessage: {
-          id: 'errorsAmoutCheck',
+          id: 'errorsAmountCheck',
         },
       })`,
       errors: [
-        {
-          message: `message with id 'errorsAmoutCheck' is duplicated`,
-        },
-        {
-          message: `message with id 'errorsAmoutCheck' is duplicated`,
-        },
-        {
-          message: `message with id 'errorsAmoutCheck' is duplicated`,
-        },
+        { message: `message with id 'errorsAmountCheck' is duplicated` },
+        { message: `message with id 'errorsAmountCheck' is duplicated` },
+        { message: `message with id 'errorsAmountCheck' is duplicated` },
       ],
     },
   ],
@@ -112,7 +104,7 @@ ruleTester.run('defineMessages processes same file multiple times do not give er
     {
       code: `defineMessages({
         firstMessage: {
-          id: 'm_reusedId',
+          id: 'reusedId',
           defaultMessage: 'first default Message',
         },
       })`,
@@ -121,7 +113,7 @@ ruleTester.run('defineMessages processes same file multiple times do not give er
     {
       code: `defineMessages({
         secondMessage: {
-          id: 'm_reusedId',
+          id: 'reusedId',
           defaultMessage: 'second default message',
         },
       })`,
@@ -130,3 +122,54 @@ ruleTester.run('defineMessages processes same file multiple times do not give er
   ],
   invalid: [],
 });
+
+
+ruleTester.run('defineMessages duplicate then fix scenario. Step 1: initial valid state', defineMessagesRule, {
+  valid: [
+    {
+      code: `defineMessages({
+        message: {
+          id: 'duplicateAndFixScenario_id',
+          defaultMessage: 'message',
+        },
+      })`,
+      filename: 'duplicateAndFix.ts',
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('defineMessages duplicate then fix scenario. Step 2: duplicate introduced', defineMessagesRule, {
+  valid: [],
+  invalid: [
+    {
+      code: `defineMessages({
+        message: {
+          id: 'duplicateAndFixScenario_id',
+          defaultMessage: 'message',
+        },
+      })`,
+      filename: 'duplicateAndFixAnotherFile.ts',
+      errors: [{ message: `message with id 'duplicateAndFixScenario_id' is duplicated` }],
+    },
+  ],
+});
+
+ruleTester.run(
+  'defineMessages duplicate then fix scenario. Step 3: duplicate removed, valid again',
+  defineMessagesRule,
+  {
+    valid: [
+      {
+        code: `defineMessages({
+          message: {
+            id: 'nonDuplicatedId',
+            defaultMessage: 'fixed message',
+          },
+        })`,
+        filename: 'duplicateAndFixAnotherFile.ts',
+      },
+    ],
+    invalid: [],
+  }
+);


### PR DESCRIPTION
As reported in https://github.com/gopollock/eslint-plugin-formatjs-no-id-duplication/issues/4. Rule implementation did not take into account that a single file could be processed more than once in a single memory process.

This PR improves this rule to correctly process the same files based on their names. Now it tracks in which files message duplication has occurred and always resets file message track records before processing them again.